### PR TITLE
New mode: trace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+config.json
+trace/*.result
+proxy/received
+
 # Ignore environment variables file
 .env
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 config.json
 trace/*.result
-proxy/received
+proxy/*.log
 
 # Ignore environment variables file
 .env

--- a/benchmarking/benchmark_main.py
+++ b/benchmarking/benchmark_main.py
@@ -63,7 +63,7 @@ class Benchmark:
         )
         provider_dir_name = "_".join(provider_names)
 
-        if self.proxy_server: # trace mode
+        if self.proxy_server:  # trace mode
             self.graph_dir = os.path.join("benchmark_graph", "trace", provider_dir_name)
         else:
             self.graph_dir = os.path.join("benchmark_graph", base_dir, provider_dir_name)

--- a/benchmarking/benchmark_main.py
+++ b/benchmarking/benchmark_main.py
@@ -211,6 +211,7 @@ class Benchmark:
                 provider.perform_trace_mode(self.proxy_server, self.load_generator, self.num_requests, self.verbosity, self.vllm_ip)
             else:
                 provider.perform_trace_mode(self.proxy_server, self.load_generator, self.num_requests, self.verbosity)
+        print()
 
         self.plot_metrics("response_times", "response_times")
         self.plot_metrics("timebetweentokens", "timebetweentokens")

--- a/loadgenerator/__init__.py
+++ b/loadgenerator/__init__.py
@@ -1,0 +1,5 @@
+from .load_generator import LoadGenerator
+
+__all__ = [
+    "LoadGenerator"
+]

--- a/loadgenerator/load_generator.py
+++ b/loadgenerator/load_generator.py
@@ -1,0 +1,33 @@
+import subprocess
+from pathlib import Path
+
+class LoadGenerator():
+    def __init__(self, target_url):
+        self.binary = './loadgenerator/LLMLoadgen'
+        self.target_url = target_url
+        
+    def send_loads(self, dataset_path, result_path, sampling_rate, recur_step, limit, max_drift, upscale=None):
+        # check dataset_path exists
+        dataset_abs_path = Path(dataset_path).resolve()
+        if not dataset_abs_path.exists:
+            raise FileNotFoundError(f'{dataset_path} (abs path: {dataset_abs_path})')
+
+        # generate command for load generator
+        cmd = [
+            self.binary, 
+            "-url", self.target_url, 
+            "-dataset_path", str(dataset_abs_path),
+            "-result_path", result_path, 
+            "-sampling_rate", str(sampling_rate),
+            "-recur_step", str(recur_step), 
+            "-limit", str(limit), 
+            "-max_drift", str(max_drift)
+        ]
+        if upscale:
+            cmd.extend(["-upscale", upscale])
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            # print(f'LoadGenerator result: {result}')
+        except subprocess.CalledProcessError as e:
+            print(f"LoadGenerator failed: {e}, stderr: {e.stderr}")

--- a/loadgenerator/load_generator.py
+++ b/loadgenerator/load_generator.py
@@ -50,7 +50,7 @@ class LoadGenerator():
             cmd.extend(["-upscale", upscale])
 
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            subprocess.run(cmd, capture_output=True, text=True, check=True)
             # print(f'LoadGenerator result: {result}')
         except subprocess.CalledProcessError as e:
             print(f"LoadGenerator failed: {e}, stderr: {e.stderr}")

--- a/loadgenerator/load_generator.py
+++ b/loadgenerator/load_generator.py
@@ -1,12 +1,35 @@
+"""
+Module for running a custom load generator binary against a target URL.
+
+This wraps subprocess execution of the LLMLoadgen binary with parameters
+"""
+
 import subprocess
 from pathlib import Path
 
 class LoadGenerator():
+    """
+    Wrapper class for executing the LLMLoadgen binary with configurable parameters.
+    """
+
     def __init__(self, target_url):
+        """
+        Initialize a LoadGenerator.
+
+        Args:
+            target_url (str): The target URL to send load against.
+        """
+
         self.binary = './loadgenerator/LLMLoadgen'
         self.target_url = target_url
-        
-    def send_loads(self, dataset_path, result_path, sampling_rate, recur_step, limit, max_drift, upscale=None):
+
+    def send_loads(
+        self, dataset_path, result_path, sampling_rate, recur_step, limit, max_drift, upscale=None
+    ):
+        """
+        Run the load generator with the specified parameters.
+        """
+
         # check dataset_path exists
         dataset_abs_path = Path(dataset_path).resolve()
         if not dataset_abs_path.exists:
@@ -14,13 +37,13 @@ class LoadGenerator():
 
         # generate command for load generator
         cmd = [
-            self.binary, 
-            "-url", self.target_url, 
+            self.binary,
+            "-url", self.target_url,
             "-dataset_path", str(dataset_abs_path),
-            "-result_path", result_path, 
+            "-result_path", result_path,
             "-sampling_rate", str(sampling_rate),
-            "-recur_step", str(recur_step), 
-            "-limit", str(limit), 
+            "-recur_step", str(recur_step),
+            "-limit", str(limit),
             "-max_drift", str(max_drift)
         ]
         if upscale:

--- a/main.py
+++ b/main.py
@@ -248,12 +248,12 @@ def main():
                 print("   ➜ Please add `vllm_ip' via CLI using `--vllm_ip <ip-addr>`.")
                 return  # Stop execution
             
-            if args.trace: # trace mode
+            if args.trace:  # trace mode
                 print("Using trace mode.")
                 print("Starting proxy server...")
                 proxy_server = ProxyServer()
                 proxy_server.start()
-                while not proxy_server.server.started: # Wait for server startup
+                while not proxy_server.server.started:  # Wait for server startup
                     pass
                 print("Loading load generator...")
                 load_generator = LoadGenerator(proxy_server.get_url())

--- a/providers/anthropic_provider.py
+++ b/providers/anthropic_provider.py
@@ -1,9 +1,9 @@
 # anthropic_provider.py
 import os
-import anthropic
-import numpy as np
 import asyncio
 from timeit import default_timer as timer
+import numpy as np
+import anthropic
 from providers.provider_interface import ProviderInterface
 
 
@@ -24,7 +24,7 @@ class Anthropic(ProviderInterface):
 
         # Model mapping for Anthropic models
         self.model_map = {
-            
+
             "claude-3.5-sonnet": "claude-3-5-sonnet-20241022",  # approx 70b
             "claude-3-opus": "claude-3-opus-20240229",  # approx 2T
             "claude-3-haiku": "claude-3-5-haiku-20241022",  # approx 20b
@@ -164,14 +164,14 @@ class Anthropic(ProviderInterface):
         except Exception as e:
             print(f"[ERROR] Streaming inference failed for model '{model}': {e}")
             return None, None
-        
+
     def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity):
         # Set handler for proxy
         async def data_handler(data, streaming):
             if streaming:
                 print("\nRequest not sent. Streaming not allowed in trace mode.")
                 return [{"error": "Streaming not allowed in trace mode."}]
-            
+
             def inference_sync():
                 try:
                     data.pop('stream')
@@ -181,7 +181,7 @@ class Anthropic(ProviderInterface):
                     model = next((k for k, v in self.model_map.items() if v == model_id))
                     if 'timeout' not in data:
                         data['timeout'] = 500
-                    
+
                     # Non-streaming inference
                     start_time = timer()
                     response = self.client.messages.create(**data)
@@ -200,19 +200,19 @@ class Anthropic(ProviderInterface):
                         print()
                         print(f"##### Generated in {elapsed_time:.2f} seconds")
                         print(f"##### Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
-                        print(f"Response: ", end="")
+                        print("Response: ", end="")
                         for block in response.content:
                             print(block.text)
 
                     return response.model_dump()
-                
+
                 except Exception as e:
                     print(f"\nInference failed: {e}")
                     return [{"error": f"Inference failed: {e}"}] if streaming else {"error": f"Inference failed: {e}"}
-            
-            response = await asyncio.to_thread(inference_sync)            
+
+            response = await asyncio.to_thread(inference_sync)
             return response
-        
+
         proxy_server.set_handler(data_handler)
 
         # Start load generator
@@ -225,7 +225,7 @@ class Anthropic(ProviderInterface):
             max_drift=100,
             upscale='ars'
         )
-            
+
     def display_response(self, response, elapsed):
         """
         Prints the response content and the time taken to generate it.

--- a/providers/aws_provider.py
+++ b/providers/aws_provider.py
@@ -1,8 +1,10 @@
 import boto3
 import os
 import time
+from timeit import default_timer as timer
 import json
 import numpy as np
+import asyncio
 from dotenv import load_dotenv
 from providers.provider_interface import ProviderInterface
 
@@ -187,6 +189,65 @@ class AWSBedrock(ProviderInterface):
         except Exception as e:
             print(f"[ERROR] Streaming inference failed: {e}")
             return None, None
+        
+    def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity):
+        # Set handler for proxy
+        async def data_handler(data, streaming):
+            if streaming:
+                print("\nRequest not sent. Streaming not allowed in trace mode.")
+                return [{"error": "Streaming not allowed in trace mode."}]
+            
+            def inference_sync():
+                try:
+                    data.pop('stream')
+                    model_id = data.pop('model')
+                    if not model_id or model_id not in self.model_map.values():
+                        raise Exception(f"Model {model_id} not found in model map.")
+                    model = next((k for k, v in self.model_map.items() if v == model_id))
+
+                    # Non-streaming inference
+                    start_time = timer()
+                    response = self.bedrock_client.invoke_model(
+                        modelId=model_id, body=json.dumps(data)
+                    )
+                    elapsed_time = timer() - start_time
+                    response = json.loads(response["body"].read())
+
+                    total_tokens = response.get("generation_token_count") or 0
+                    tbt = elapsed_time / max(total_tokens, 1)
+                    tps = (total_tokens / elapsed_time)
+                    self.log_metrics(model, "response_times", elapsed_time)
+                    self.log_metrics(model, "totaltokens", total_tokens)
+                    self.log_metrics(model, "timebetweentokens", tbt)
+                    self.log_metrics(model, "tps", tps)
+
+                    if verbosity:
+                        print()
+                        print(f"##### Generated in {elapsed_time:.2f} seconds")
+                        print(f"##### Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
+                        print(f"Response: {response.get('generation', '')}")
+
+                    return response
+                
+                except Exception as e:
+                    print(f"\nInference failed: {e}")
+                    return [{"error": f"Inference failed: {e}"}] if streaming else {"error": f"Inference failed: {e}"}
+            
+            response = await asyncio.to_thread(inference_sync)            
+            return response
+        
+        proxy_server.set_handler(data_handler)
+
+        # Start load generator
+        load_generator.send_loads(
+            self.trace_dataset_path,
+            self.trace_result_path,
+            sampling_rate=100,
+            recur_step=10,
+            limit=num_requests,
+            max_drift=100,
+            upscale='ars'
+        )
 
 
 # Example Usage

--- a/providers/aws_provider.py
+++ b/providers/aws_provider.py
@@ -1,11 +1,11 @@
-import boto3
 import os
 import time
 from timeit import default_timer as timer
+import asyncio
 import json
 import numpy as np
-import asyncio
 from dotenv import load_dotenv
+import boto3
 from providers.provider_interface import ProviderInterface
 
 
@@ -133,7 +133,7 @@ class AWSBedrock(ProviderInterface):
                     except Exception:
                         # print(f"[DEBUG] Failed to decode chunk: {e}")
                         continue
-                    
+
                     if chunk["stop_reason"] == 'length':
                         total_time = time.perf_counter() - start_time
                         print(chunk)
@@ -189,14 +189,14 @@ class AWSBedrock(ProviderInterface):
         except Exception as e:
             print(f"[ERROR] Streaming inference failed: {e}")
             return None, None
-        
+
     def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity):
         # Set handler for proxy
         async def data_handler(data, streaming):
             if streaming:
                 print("\nRequest not sent. Streaming not allowed in trace mode.")
                 return [{"error": "Streaming not allowed in trace mode."}]
-            
+
             def inference_sync():
                 try:
                     data.pop('stream')
@@ -228,14 +228,14 @@ class AWSBedrock(ProviderInterface):
                         print(f"Response: {response.get('generation', '')}")
 
                     return response
-                
+
                 except Exception as e:
                     print(f"\nInference failed: {e}")
                     return [{"error": f"Inference failed: {e}"}] if streaming else {"error": f"Inference failed: {e}"}
-            
-            response = await asyncio.to_thread(inference_sync)            
+
+            response = await asyncio.to_thread(inference_sync)
             return response
-        
+
         proxy_server.set_handler(data_handler)
 
         # Start load generator

--- a/providers/azure_provider.py
+++ b/providers/azure_provider.py
@@ -207,9 +207,9 @@ class Azure(ProviderInterface):
                         print()
                         print(f"##### Generated in {elapsed_time:.2f} seconds")
                         print(f"##### Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
-                        print(f"Response: {response}")
+                        print(f"Response: {response['choices'][0]['message']['content']}")
 
-                    return response.to_dict()
+                    return response.as_dict()
 
                 except Exception as e:
                     print(f"\nInference failed: {e}")

--- a/providers/azure_provider.py
+++ b/providers/azure_provider.py
@@ -1,9 +1,10 @@
 import os
 import numpy as np
+import asyncio
 from providers.base_provider import ProviderInterface
 from time import perf_counter as timer
 from azure.ai.inference import ChatCompletionsClient
-from azure.ai.inference.models import SystemMessage, UserMessage
+from azure.ai.inference.models import SystemMessage, UserMessage, AssistantMessage
 from azure.core.credentials import AzureKeyCredential
 
 
@@ -160,3 +161,72 @@ class Azure(ProviderInterface):
         except Exception as e:
             print(f"[ERROR] Streaming inference failed for model '{model}': {e}")
             return None, None
+        
+    def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity):
+        # Set handler for proxy
+        async def data_handler(data, streaming):
+            if streaming:
+                print("\nRequest not sent. Streaming not allowed in trace mode.")
+                return [{"error": "Streaming not allowed in trace mode."}]
+            
+            def inference_sync():
+                try:
+                    model_id = data.get('model')
+                    if not model_id or model_id not in self.model_map.values():
+                        raise Exception(f"Model {model_id} not found in model map.")
+                    model = next((k for k, v in self.model_map.items() if v == model_id))
+
+                    # Format prompt messages
+                    for i, m in enumerate(data['messages']):
+                        match m['role']:
+                            case 'system':
+                                data['messages'][i] = SystemMessage(m['content'])
+                            case 'assistant':
+                                data['messages'][i] = AssistantMessage(m['content'])
+                            case 'user':
+                                data['messages'][i] = UserMessage(m['content'])
+                            case _:
+                                raise Exception(f"Role {m['role']} not supported.")
+                                        
+                    # Non-streaming inference
+                    self._ensure_client()
+                    start_time = timer()
+                    response = self._client.complete(**data)
+                    elapsed_time = timer() - start_time
+
+                    usage = response.get("usage")
+                    total_tokens = usage.get("completion_tokens") or 0
+                    tbt = elapsed_time / max(total_tokens, 1)
+                    tps = (total_tokens / elapsed_time)
+                    self.log_metrics(model, "response_times", elapsed_time)
+                    self.log_metrics(model, "totaltokens", total_tokens)
+                    self.log_metrics(model, "timebetweentokens", tbt)
+                    self.log_metrics(model, "tps", tps)
+
+                    if verbosity:
+                        print()
+                        print(f"##### Generated in {elapsed_time:.2f} seconds")
+                        print(f"##### Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
+                        print(f"Response: {response}")
+                        
+                    return response.to_dict()
+                
+                except Exception as e:
+                    print(f"\nInference failed: {e}")
+                    return [{"error": f"Inference failed: {e}"}] if streaming else {"error": f"Inference failed: {e}"}
+            
+            response = await asyncio.to_thread(inference_sync)            
+            return response
+        
+        proxy_server.set_handler(data_handler)
+
+        # Start load generator
+        load_generator.send_loads(
+            self.trace_dataset_path,
+            self.trace_result_path,
+            sampling_rate=100,
+            recur_step=10,
+            limit=num_requests,
+            max_drift=100,
+            upscale='ars'
+        )

--- a/providers/azure_provider.py
+++ b/providers/azure_provider.py
@@ -1,11 +1,11 @@
 import os
-import numpy as np
 import asyncio
-from providers.base_provider import ProviderInterface
 from time import perf_counter as timer
+import numpy as np
 from azure.ai.inference import ChatCompletionsClient
 from azure.ai.inference.models import SystemMessage, UserMessage, AssistantMessage
 from azure.core.credentials import AzureKeyCredential
+from providers.base_provider import ProviderInterface
 
 
 class Azure(ProviderInterface):
@@ -89,7 +89,7 @@ class Azure(ProviderInterface):
                 print(f"Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
                 print(f"Response: {response['choices'][0]['message']['content']}")
             return response
-        
+
         except Exception as e:
             print(f"[ERROR] Inference failed for model '{model}': {e}")
             return None, None
@@ -161,14 +161,14 @@ class Azure(ProviderInterface):
         except Exception as e:
             print(f"[ERROR] Streaming inference failed for model '{model}': {e}")
             return None, None
-        
+
     def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity):
         # Set handler for proxy
         async def data_handler(data, streaming):
             if streaming:
                 print("\nRequest not sent. Streaming not allowed in trace mode.")
                 return [{"error": "Streaming not allowed in trace mode."}]
-            
+
             def inference_sync():
                 try:
                     model_id = data.get('model')
@@ -187,7 +187,7 @@ class Azure(ProviderInterface):
                                 data['messages'][i] = UserMessage(m['content'])
                             case _:
                                 raise Exception(f"Role {m['role']} not supported.")
-                                        
+
                     # Non-streaming inference
                     self._ensure_client()
                     start_time = timer()
@@ -208,16 +208,16 @@ class Azure(ProviderInterface):
                         print(f"##### Generated in {elapsed_time:.2f} seconds")
                         print(f"##### Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
                         print(f"Response: {response}")
-                        
+
                     return response.to_dict()
-                
+
                 except Exception as e:
                     print(f"\nInference failed: {e}")
                     return [{"error": f"Inference failed: {e}"}] if streaming else {"error": f"Inference failed: {e}"}
-            
-            response = await asyncio.to_thread(inference_sync)            
+
+            response = await asyncio.to_thread(inference_sync)
             return response
-        
+
         proxy_server.set_handler(data_handler)
 
         # Start load generator

--- a/providers/base_provider.py
+++ b/providers/base_provider.py
@@ -1,6 +1,7 @@
 # base_provider.py for chat completions api
 from timeit import default_timer as timer
 import numpy as np
+import asyncio, json
 from providers.provider_interface import ProviderInterface
 
 
@@ -127,6 +128,66 @@ class BaseProvider(ProviderInterface):
         except Exception as e:
             print(f"[ERROR] Streaming inference failed for model '{model}': {e}")
             return None, None
+        
+    def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity):
+        # Set handler for proxy
+        async def data_handler(data, streaming):
+            if streaming:
+                print("\nRequest not sent. Streaming not allowed in trace mode.")
+                return [{"error": "Streaming not allowed in trace mode."}]
+            
+            def inference_sync():
+                try:
+                    model_id = data.get('model')
+                    if not model_id or model_id not in self.model_map.values():
+                        raise Exception(f"Model {model_id} not found in model map.")
+                    model = next((k for k, v in self.model_map.items() if v == model_id))
+                    if 'timeout' not in data:
+                        data['timeout'] = (1, 2)
+
+                    # Non-streaming inference
+                    start_time = timer()
+                    response = self.client.chat.completions.create(**data)
+                    elapsed_time = timer() - start_time
+
+                    usage = getattr(response, "usage", None)
+                    total_tokens = 0
+                    if usage:
+                        total_tokens = getattr(usage, "completion_tokens", None) or getattr(usage, "output_tokens", None) or 0
+                    tbt = elapsed_time / max(total_tokens, 1)
+                    tps = (total_tokens / elapsed_time)
+                    self.log_metrics(model, "totaltokens", total_tokens)
+                    self.log_metrics(model, "timebetweentokens", tbt)
+                    self.log_metrics(model, "tps", tps)
+                    self.log_metrics(model, "response_times", elapsed_time)
+
+                    if verbosity:
+                        print()
+                        print(f"##### Generated in {elapsed_time:.2f} seconds")
+                        print(f"##### Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
+                        print(f"Response: {response.choices[0].message.content}")
+
+                    return json.loads(response.json())
+                
+                except Exception as e:
+                    print(f"\nInference failed: {e}")
+                    return [{"error": f"Inference failed: {e}"}] if streaming else {"error": f"Inference failed: {e}"}
+            
+            response = await asyncio.to_thread(inference_sync)            
+            return response
+        
+        proxy_server.set_handler(data_handler)
+
+        # Start load generator
+        load_generator.send_loads(
+            self.trace_dataset_path,
+            self.trace_result_path,
+            sampling_rate=100,
+            recur_step=10,
+            limit=num_requests,
+            max_drift=100,
+            upscale='ars'
+        )
 
     def display_response(self, response, elapsed):
         """Display response."""

--- a/providers/cloudflare_provider.py
+++ b/providers/cloudflare_provider.py
@@ -2,6 +2,7 @@ import os
 import time
 import requests
 import numpy as np
+import asyncio
 from timeit import default_timer as timer
 from providers.provider_interface import ProviderInterface
 
@@ -162,3 +163,67 @@ class Cloudflare(ProviderInterface):
         except Exception as e:
             print(f"[ERROR] Streaming inference failed for model '{model}': {e}")
             return None, None
+        
+    def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity):
+        # Set handler for proxy
+        async def data_handler(data, streaming):
+            if streaming:
+                print("\nRequest not sent. Streaming not allowed in trace mode.")
+                return [{"error": "Streaming not allowed in trace mode."}]
+            
+            def inference_sync():
+                try:
+                    model_id = data.pop('model')
+                    if not model_id or model_id not in self.model_map.values():
+                        raise Exception(f"Model {model_id} not found in model map.")
+                    model = next((k for k, v in self.model_map.items() if v == model_id))
+
+                    # Non-streaming inference                    
+                    start_time = timer()
+                    response = requests.post(
+                        f"https://api.cloudflare.com/client/v4/accounts/{self.cloudflare_account_id}/ai/run/{model_id}",
+                        headers={"Authorization": f"Bearer {self.cloudflare_api_token}"},
+                        timeout=data.pop('timeout', 500),
+                        json=data,
+                        stream=False
+                    )
+                    elapsed_time = timer() - start_time
+                    response = response.json()
+
+                    meta = response.get("result", {})
+                    usage = meta.get("usage", {})
+                    total_tokens = usage.get("completion_tokens") or 0
+                    tbt = elapsed_time / max(total_tokens, 1)
+                    tps = (total_tokens / elapsed_time)
+                    self.log_metrics(model, "response_times", elapsed_time)
+                    self.log_metrics(model, "totaltokens", total_tokens)
+                    self.log_metrics(model, "timebetweentokens", tbt)
+                    self.log_metrics(model, "tps", tps)
+
+                    if verbosity:
+                        print()
+                        print(f"##### Generated in {elapsed_time:.2f} seconds")
+                        print(f"##### Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
+                        print(f"Response: {response['result']['response']}")
+                    
+                    return response
+                
+                except Exception as e:
+                    print(f"\nInference failed: {e}")
+                    return [{"error": f"Inference failed: {e}"}] if streaming else {"error": f"Inference failed: {e}"}
+            
+            response = await asyncio.to_thread(inference_sync)            
+            return response
+        
+        proxy_server.set_handler(data_handler)
+
+        # Start load generator
+        load_generator.send_loads(
+            self.trace_dataset_path,
+            self.trace_result_path,
+            sampling_rate=100,
+            recur_step=10,
+            limit=num_requests,
+            max_drift=100,
+            upscale='ars'
+        )

--- a/providers/google_provider.py
+++ b/providers/google_provider.py
@@ -1,9 +1,9 @@
 import os
-from providers.provider_interface import ProviderInterface
-import google.generativeai as genai
+import asyncio
 from timeit import default_timer as timer
 import numpy as np
-import asyncio
+import google.generativeai as genai
+from providers.provider_interface import ProviderInterface
 
 
 class GoogleGemini(ProviderInterface):
@@ -65,7 +65,7 @@ class GoogleGemini(ProviderInterface):
             total_tokens = (getattr(usage, "candidates_token_count", 0) or 0) if usage else 0
 
             tbt = elapsed / max(total_tokens, 1)
-            tps = (total_tokens / elapsed)
+            tps = total_tokens / elapsed
 
             self.log_metrics(model, "response_times", elapsed)
             self.log_metrics(model, "totaltokens", total_tokens)
@@ -77,7 +77,7 @@ class GoogleGemini(ProviderInterface):
                 print(response.text)
                 print(f"\nGenerated in {elapsed:.2f} seconds")
             return elapsed
-        
+
         except Exception as e:
             print(f"[ERROR] Inference failed for model '{model}': {e}")
             return None, None
@@ -160,14 +160,14 @@ class GoogleGemini(ProviderInterface):
         )
 
         return streamed_output
-    
+
     def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity):
         # Set handler for proxy
         async def data_handler(data, streaming):
             if streaming:
                 print("\nRequest not sent. Streaming not allowed in trace mode.")
                 return [{"error": "Streaming not allowed in trace mode."}]
-            
+
             def inference_sync():
                 try:
                     model_id = data.pop('model')
@@ -175,7 +175,7 @@ class GoogleGemini(ProviderInterface):
                         raise Exception(f"Model {model_id} not found in model map.")
                     model = next((k for k, v in self.model_map.items() if v == model_id))
                     self._initialize_model(model_id)
-                                        
+
                     # Non-streaming inference
                     start_time = timer()
                     response = self.model.generate_content(
@@ -199,16 +199,16 @@ class GoogleGemini(ProviderInterface):
                         print(f"##### Generated in {elapsed_time:.2f} seconds")
                         print(f"##### Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
                         print(f"Response: {response.text}")
-                        
+
                     return response.to_dict()
-                
+
                 except Exception as e:
                     print(f"\nInference failed: {e}")
                     return [{"error": f"Inference failed: {e}"}] if streaming else {"error": f"Inference failed: {e}"}
-            
-            response = await asyncio.to_thread(inference_sync)            
+
+            response = await asyncio.to_thread(inference_sync)
             return response
-        
+
         proxy_server.set_handler(data_handler)
 
         # Start load generator

--- a/providers/google_provider.py
+++ b/providers/google_provider.py
@@ -3,6 +3,7 @@ from providers.provider_interface import ProviderInterface
 import google.generativeai as genai
 from timeit import default_timer as timer
 import numpy as np
+import asyncio
 
 
 class GoogleGemini(ProviderInterface):
@@ -159,3 +160,64 @@ class GoogleGemini(ProviderInterface):
         )
 
         return streamed_output
+    
+    def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity):
+        # Set handler for proxy
+        async def data_handler(data, streaming):
+            if streaming:
+                print("\nRequest not sent. Streaming not allowed in trace mode.")
+                return [{"error": "Streaming not allowed in trace mode."}]
+            
+            def inference_sync():
+                try:
+                    model_id = data.pop('model')
+                    if not model_id or model_id not in self.model_map.values():
+                        raise Exception(f"Model {model_id} not found in model map.")
+                    model = next((k for k, v in self.model_map.items() if v == model_id))
+                    self._initialize_model(model_id)
+                                        
+                    # Non-streaming inference
+                    start_time = timer()
+                    response = self.model.generate_content(
+                        contents=data.pop('contents'),
+                        stream=data.pop('stream'),
+                        generation_config=data
+                    )
+                    elapsed_time = timer() - start_time
+
+                    usage = getattr(response, "usage_metadata", None)
+                    total_tokens = (getattr(usage, "candidates_token_count", 0) or 0) if usage else 0
+                    tbt = elapsed_time / max(total_tokens, 1)
+                    tps = (total_tokens / elapsed_time)
+                    self.log_metrics(model, "response_times", elapsed_time)
+                    self.log_metrics(model, "totaltokens", total_tokens)
+                    self.log_metrics(model, "timebetweentokens", tbt)
+                    self.log_metrics(model, "tps", tps)
+
+                    if verbosity:
+                        print()
+                        print(f"##### Generated in {elapsed_time:.2f} seconds")
+                        print(f"##### Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
+                        print(f"Response: {response.text}")
+                        
+                    return response.to_dict()
+                
+                except Exception as e:
+                    print(f"\nInference failed: {e}")
+                    return [{"error": f"Inference failed: {e}"}] if streaming else {"error": f"Inference failed: {e}"}
+            
+            response = await asyncio.to_thread(inference_sync)            
+            return response
+        
+        proxy_server.set_handler(data_handler)
+
+        # Start load generator
+        load_generator.send_loads(
+            self.trace_dataset_path,
+            self.trace_result_path,
+            sampling_rate=100,
+            recur_step=10,
+            limit=num_requests,
+            max_drift=100,
+            upscale='ars'
+        )

--- a/providers/provider_interface.py
+++ b/providers/provider_interface.py
@@ -25,6 +25,10 @@ class ProviderInterface(ABC):
             "timebetweentokens_p95": {},
         }
 
+        # for trace mode
+        self.trace_dataset_path = f'./trace/{self.__class__.__name__}.dataset'
+        self.trace_result_path = f'./trace/{self.__class__.__name__}.result'
+
     def log_metrics(self, model_name, metric, value):
         """
         Logs metrics
@@ -46,6 +50,12 @@ class ProviderInterface(ABC):
     def perform_inference_streaming(self, model, prompt):
         """
         perform_inference_streaming
+        """
+
+    @abstractmethod
+    def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity):
+        """
+        perform_trace_mode
         """
 
     @abstractmethod

--- a/providers/vllm_provider.py
+++ b/providers/vllm_provider.py
@@ -65,7 +65,7 @@ class vLLM(ProviderInterface):
             if verbosity:
                 print(f"Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
                 print(f"#### _Generated in *{elapsed:.2f}* seconds_")
-            
+
             print(response)
             inference = response.json()
             print(inference)
@@ -130,7 +130,7 @@ class vLLM(ProviderInterface):
                         time_to_next_token = time.perf_counter()
                         inter_token_latency = time_to_next_token - prev_token_time
                         prev_token_time = time_to_next_token
-                         
+
                         chunk = line_str[6:]  # Remove "data: " prefix
                         chunk_json = json.loads(chunk)
                         token_text = chunk_json["choices"][0]["text"]
@@ -141,7 +141,7 @@ class vLLM(ProviderInterface):
 
             avg_tbt = sum(inter_token_latencies) / len(inter_token_latencies)
             if verbosity:
-    
+
                 print(
                     f"\nNumber of output tokens/chunks: {len(inter_token_latencies) + 1}, "
                     f"Time to First Token (TTFT): {ttft:.4f} seconds, Avg TBT: {avg_tbt}, Total Response Time: {total_time:.4f} seconds"
@@ -164,14 +164,14 @@ class vLLM(ProviderInterface):
         except Exception as e:
             print(f"Error during streaming inference: {e}")
             return None, None
-        
+
     def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity, vllm_ip):
         # Set handler for proxy
         async def data_handler(data, streaming):
             if streaming:
                 print("\nRequest not sent. Streaming not allowed in trace mode.")
                 return [{"error": "Streaming not allowed in trace mode."}]
-            
+
             def inference_sync():
                 try:
                     model_id = data.get('model')
@@ -207,14 +207,14 @@ class vLLM(ProviderInterface):
                         print(f"Response: {response.text}")
 
                     return response
-                
+
                 except Exception as e:
                     print(f"\nInference failed: {e}")
                     return [{"error": f"Inference failed: {e}"}] if streaming else {"error": f"Inference failed: {e}"}
-            
-            response = await asyncio.to_thread(inference_sync)            
+
+            response = await asyncio.to_thread(inference_sync)
             return response
-        
+
         proxy_server.set_handler(data_handler)
 
         # Start load generator
@@ -227,4 +227,3 @@ class vLLM(ProviderInterface):
             max_drift=100,
             upscale='ars'
         )
-

--- a/providers/vllm_provider.py
+++ b/providers/vllm_provider.py
@@ -204,7 +204,7 @@ class vLLM(ProviderInterface):
                         print()
                         print(f"##### Generated in {elapsed_time:.2f} seconds")
                         print(f"##### Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
-                        print(f"Response: {response.text}")
+                        print(f"Response: {response}")
 
                     return response
 

--- a/providers/vllm_provider.py
+++ b/providers/vllm_provider.py
@@ -1,6 +1,7 @@
 import time
 import requests
 import numpy as np
+import asyncio
 from timeit import default_timer as timer
 from providers.provider_interface import ProviderInterface
 import json
@@ -163,3 +164,67 @@ class vLLM(ProviderInterface):
         except Exception as e:
             print(f"Error during streaming inference: {e}")
             return None, None
+        
+    def perform_trace_mode(self, proxy_server, load_generator, num_requests, verbosity, vllm_ip):
+        # Set handler for proxy
+        async def data_handler(data, streaming):
+            if streaming:
+                print("\nRequest not sent. Streaming not allowed in trace mode.")
+                return [{"error": "Streaming not allowed in trace mode."}]
+            
+            def inference_sync():
+                try:
+                    model_id = data.get('model')
+                    if not model_id or model_id not in self.model_map.values():
+                        raise Exception(f"Model {model_id} not found in model map.")
+                    model = next((k for k, v in self.model_map.items() if v == model_id))
+
+                    # Non-streaming inference
+                    start_time = timer()
+                    response = requests.post(
+                        f"http:/{vllm_ip}:{self.vllm_port}/v1/completions",
+                        headers={"Content-Type": "application/json"},
+                        timeout=data.pop('timeout', 1800),
+                        json=data,
+                        stream=False
+                    )
+                    elapsed_time = timer() - start_time
+                    response = response.json()
+
+                    usage = response.get("usage") or {}
+                    total_tokens = usage.get("completion_tokens")
+                    tbt = elapsed_time / max(total_tokens, 1)
+                    tps = (total_tokens / elapsed_time)
+                    self.log_metrics(model, "totaltokens", total_tokens)
+                    self.log_metrics(model, "timebetweentokens", tbt)
+                    self.log_metrics(model, "tps", tps)
+                    self.log_metrics(model, "response_times", elapsed_time)
+
+                    if verbosity:
+                        print()
+                        print(f"##### Generated in {elapsed_time:.2f} seconds")
+                        print(f"##### Tokens: {total_tokens}, Avg TBT: {tbt:.4f}s, TPS: {tps:.2f}")
+                        print(f"Response: {response.text}")
+
+                    return response
+                
+                except Exception as e:
+                    print(f"\nInference failed: {e}")
+                    return [{"error": f"Inference failed: {e}"}] if streaming else {"error": f"Inference failed: {e}"}
+            
+            response = await asyncio.to_thread(inference_sync)            
+            return response
+        
+        proxy_server.set_handler(data_handler)
+
+        # Start load generator
+        load_generator.send_loads(
+            self.trace_dataset_path,
+            self.trace_result_path,
+            sampling_rate=100,
+            recur_step=10,
+            limit=num_requests,
+            max_drift=100,
+            upscale='ars'
+        )
+

--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -1,0 +1,5 @@
+from .proxy_server import ProxyServer
+
+__all__ = [
+    "ProxyServer"
+]

--- a/proxy/proxy_server.py
+++ b/proxy/proxy_server.py
@@ -2,7 +2,8 @@ import threading
 import uvicorn
 from fastapi import FastAPI, Request
 
-import time, json
+import json
+import time
 
 class ProxyServer(threading.Thread):
     def __init__(self, host="127.0.0.1", port=8001):
@@ -10,7 +11,7 @@ class ProxyServer(threading.Thread):
         self._host = host
         self._port = port
         self._app = FastAPI()
-        self._on_receive = [] # Must be a list to allow updating handler without restarting proxy
+        self._on_receive = []  # Must be a list to allow updating handler without restarting proxy
         self.server = None
 
         @self._app.post("/")
@@ -18,13 +19,13 @@ class ProxyServer(threading.Thread):
             if not self._on_receive:
                 return {"status": "error", "message": "handler not set"}
             
-            data = await request.json() # dict
+            data = await request.json()  # dict
             # Log data
             with open('./proxy/traffic.log', 'a') as f:
                 f.write(f'[Client] {json.dumps(data)}\n')
 
             streaming = data.get("stream", False)
-            response = await self._on_receive[0](data, streaming) # List[dict] if streaming, else dict
+            response = await self._on_receive[0](data, streaming)  # List[dict] if streaming, else dict
             
             # Log response
             with open('./proxy/traffic.log', 'a') as f:
@@ -58,6 +59,7 @@ class ProxyServer(threading.Thread):
         )
         self.server = uvicorn.Server(config)
         self.server.run()
+
 
 if __name__ == '__main__':
     proxy_server = ProxyServer()

--- a/proxy/proxy_server.py
+++ b/proxy/proxy_server.py
@@ -18,13 +18,16 @@ class ProxyServer(threading.Thread):
             if not self._on_receive:
                 return {"status": "error", "message": "handler not set"}
             
-            data = await request.json()
+            data = await request.json() # dict
+            # Log relayed data
+            with open('./proxy/received', 'a') as f:
+                f.write(f'[Client] {json.dumps(data)}\n')
+
             streaming = data.get("stream", False)
             response = await self._on_receive[0](data, streaming) # List[dict] if streaming, else dict
             
-            # PROXY DEBUG
+            # Log response
             with open('./proxy/received', 'a') as f:
-                f.write(f'[Client] {json.dumps(data)}\n')
                 if streaming:
                     for line in response:
                         f.write(f'[Server] {json.dumps(line)}\n')

--- a/proxy/proxy_server.py
+++ b/proxy/proxy_server.py
@@ -1,0 +1,65 @@
+import threading
+import uvicorn
+from fastapi import FastAPI, Request
+
+import time, json
+
+class ProxyServer(threading.Thread):
+    def __init__(self, host="127.0.0.1", port=8001):
+        super().__init__(daemon=True)
+        self._host = host
+        self._port = port
+        self._app = FastAPI()
+        self._on_receive = [] # Must be a list to allow updating handler without restarting proxy
+        self.server = None
+
+        @self._app.post("/")
+        async def endpoint(request: Request):
+            if not self._on_receive:
+                return {"status": "error", "message": "handler not set"}
+            
+            data = await request.json()
+            streaming = data.get("stream", False)
+            response = await self._on_receive[0](data, streaming) # List[dict] if streaming, else dict
+            
+            # PROXY DEBUG
+            with open('./proxy/received', 'a') as f:
+                f.write(f'[Client] {json.dumps(data)}\n')
+                if streaming:
+                    for line in response:
+                        f.write(f'[Server] {json.dumps(line)}\n')
+                else:
+                    f.write(f'[Server] {json.dumps(response)}\n')
+
+            return {"full_response": response} if streaming else response
+
+    def set_handler(self, handler):
+        """
+        Set method to handle received data
+        """
+        if not self._on_receive:
+            self._on_receive.append(handler)
+        else:
+            self._on_receive[0] = handler
+
+    def get_url(self):
+        return f'http://{self._host}:{self._port}'
+    
+    def run(self):
+        config = uvicorn.Config(
+            self._app,
+            host=self._host,
+            port=self._port,
+            log_level="info",
+            access_log=False
+        )
+        self.server = uvicorn.Server(config)
+        self.server.run()
+
+if __name__ == '__main__':
+    proxy_server = ProxyServer()
+    proxy_server.start()
+
+    time.sleep(5)
+
+    print("Check if thread is blocking.")

--- a/proxy/proxy_server.py
+++ b/proxy/proxy_server.py
@@ -19,15 +19,15 @@ class ProxyServer(threading.Thread):
                 return {"status": "error", "message": "handler not set"}
             
             data = await request.json() # dict
-            # Log relayed data
-            with open('./proxy/received', 'a') as f:
+            # Log data
+            with open('./proxy/traffic.log', 'a') as f:
                 f.write(f'[Client] {json.dumps(data)}\n')
 
             streaming = data.get("stream", False)
             response = await self._on_receive[0](data, streaming) # List[dict] if streaming, else dict
             
             # Log response
-            with open('./proxy/received', 'a') as f:
+            with open('./proxy/traffic.log', 'a') as f:
                 if streaming:
                     for line in response:
                         f.write(f'[Server] {json.dumps(line)}\n')

--- a/trace/AWSBedrock.dataset
+++ b/trace/AWSBedrock.dataset
@@ -1,0 +1,35 @@
+[
+    {
+        "Content-Type": "application/json"
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "meta.llama3-70b-instruct-v1:0",
+            "prompt": "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\nYou are a helpful coding assistant.\n<|start_header_id|>user<|end_header_id|>\nWrite me a short story about a dragon.\n<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>",
+            "max_gen_len": 100,
+            "temperature": 0.8,
+            "stream": false
+        }
+    },
+    {
+        "timestamp": "00:00:01.000000",
+        "data": {
+            "model": "meta.llama3-70b-instruct-v1:0",
+            "prompt": "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\nYou are a helpful coding assistant.\n<|start_header_id|>user<|end_header_id|>\nWrite me a short story about a dragon.\n<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>",
+            "max_gen_len": 100,
+            "temperature": 0.8,
+            "stream": true
+        }
+    },
+    {
+        "timestamp": "00:00:02.000000",
+        "data": {
+            "model": "meta.llama3-70b-instruct-v1:0",
+            "prompt": "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\nYou are a helpful coding assistant.\n<|start_header_id|>user<|end_header_id|>\nWrite me a short story about a dragon.\n<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>",
+            "max_gen_len": 100,
+            "temperature": 0.8,
+            "stream": false
+        }
+    }
+]

--- a/trace/Anthropic.dataset
+++ b/trace/Anthropic.dataset
@@ -1,0 +1,44 @@
+[
+    {
+        "Content-Type": "application/json"
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {"role": "user", "content": "Hello!"}
+            ],
+            "max_tokens": 100,
+            "stop_sequences": [
+                "\nUser:"
+            ],
+            "temperature": 0.7,
+            "stream": false
+        }
+    },
+    {
+        "timestamp": "00:00:01.000000",
+        "data": {
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {"role": "user", "content": "Who are you?"}
+            ],
+            "max_tokens": 100,
+            "temperature": 0.7,
+            "stream": false
+        }
+    },
+    {
+        "timestamp": "00:00:02.000000",
+        "data": {
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {"role": "user", "content": "Who are you?"}
+            ],
+            "max_tokens": 100,
+            "temperature": 0.7,
+            "stream": true
+        }
+    }
+]

--- a/trace/Azure.dataset
+++ b/trace/Azure.dataset
@@ -1,0 +1,18 @@
+[
+    {
+        "Content-Type": "application/json"
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "Mistral-Large-2411-yatcd",
+            "stream": false,
+            "messages": [
+                {"role": "system", "content": "You are a helpful veterinarian."},
+                {"role": "user", "content": "Tell me a joke about cats."}
+            ],
+            "temperature": 0.7,
+            "max_tokens": 200
+        }
+    }
+]

--- a/trace/Cloudflare.dataset
+++ b/trace/Cloudflare.dataset
@@ -1,0 +1,39 @@
+[
+    {
+        "Content-Type": "application/json"
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            "messages": [
+                {"role": "user", "content": "Hello!"}
+            ],
+            "max_tokens": 100,
+            "stream": false
+        }
+    },
+    {
+        "timestamp": "00:00:01.000000",
+        "data": {
+            "model": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            "messages": [
+                {"role": "user", "content": "Hello!"}
+            ],
+            "max_tokens": 100,
+            "stream": true
+        }
+    },
+    {
+        "timestamp": "00:00:02.000000",
+        "data": {
+            "model": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            "messages": [
+                {"role": "system", "content": "You are a math tutor."},
+                {"role": "user", "content": "Hello!"}
+            ],
+            "max_tokens": 100,
+            "stream": true
+        }
+    }
+]

--- a/trace/GoogleGemini.dataset
+++ b/trace/GoogleGemini.dataset
@@ -1,0 +1,40 @@
+[
+    {
+        "Content-Type": "application/json"
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "gemini-1.5-flash",
+            "stream": false,
+            "contents": [
+                {"role": "user", "parts": ["Who are you?"]}
+            ],
+            "temperature": 0.7,
+            "max_output_tokens": 200
+        }
+    },
+    {
+        "timestamp": "00:00:01.000000",
+        "data": {
+            "model": "gemini-1.5-flash",
+            "stream": false,
+            "contents": [
+                {"role": "model", "parts": ["You are a tour guide."]},
+                {"role": "user", "parts": ["Recommend dinner places in Singapore."]}
+            ],
+            "temperature": 0.7,
+            "max_output_tokens": 200
+        }
+    },
+    {
+        "timestamp": "00:00:02.000000",
+        "data": {
+            "model": "gemini-1.5-flash",
+            "stream": true,
+            "contents": [
+                {"role": "user", "parts": ["Hello!"]}
+            ]
+        }
+    }
+]

--- a/trace/GroqProvider.dataset
+++ b/trace/GroqProvider.dataset
@@ -1,0 +1,16 @@
+[
+    {
+        "Content-Type": "application/json"
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "llama-3.3-70b-versatile",
+            "messages": [
+                {"role": "user", "content": "Hello!"}
+            ],
+            "max_tokens": 100,
+            "stream": false
+        }
+    }
+]

--- a/trace/Hyperbolic.dataset
+++ b/trace/Hyperbolic.dataset
@@ -1,0 +1,16 @@
+[
+    {
+        "Content-Type": "application/json"
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "meta-llama/Meta-Llama-3.1-70B-Instruct",
+            "messages": [
+                {"role": "user", "content": "Hello!"}
+            ],
+            "max_tokens": 100,
+            "stream": false
+        }
+    }
+]

--- a/trace/Open_AI.dataset
+++ b/trace/Open_AI.dataset
@@ -1,0 +1,27 @@
+[
+    {
+        "Content-Type": "application/json"
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "gpt-4o",
+            "messages": [
+                {"role": "user", "content": "Hello!"}
+            ],
+            "max_tokens": 100,
+            "stream": false
+        }
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "gpt-4o",
+            "messages": [
+                {"role": "user", "content": "Hello!"}
+            ],
+            "max_tokens": 100,
+            "stream": true
+        }
+    }
+]

--- a/trace/PerplexityAI.dataset
+++ b/trace/PerplexityAI.dataset
@@ -1,0 +1,16 @@
+[
+    {
+        "Content-Type": "application/json"
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "sonar-pro",
+            "messages": [
+                {"role": "user", "content": "Hello!"}
+            ],
+            "max_tokens": 100,
+            "stream": false
+        }
+    }
+]

--- a/trace/TogetherAI.dataset
+++ b/trace/TogetherAI.dataset
@@ -1,0 +1,16 @@
+[
+    {
+        "Content-Type": "application/json"
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            "messages": [
+                {"role": "user", "content": "Hello!"}
+            ],
+            "max_tokens": 100,
+            "stream": false
+        }
+    }
+]

--- a/trace/vLLM.dataset
+++ b/trace/vLLM.dataset
@@ -1,0 +1,15 @@
+[
+    {
+        "Content-Type": "application/json"
+    },
+    {
+        "timestamp": "00:00:00.000000",
+        "data": {
+            "model": "meta-llama/Llama-3.1-8B",
+            "prompt": "System: You are a tour guide \n User: Introduce yourself",
+            "max_tokens": 100,
+            "temperature": 0.7,
+            "stream": false
+        }
+    }
+]


### PR DESCRIPTION
## Overview
An integration of LLMetrics and LLMLoadgen to allow using trace dataset files as input to providers. To use trace mode, supply 
`-t`. Note that some arguments in `config.json` is still required for provider selections, limiting max number of requests, and verbosity choice.

## Usage
```
python main.py -c config.json -t
```
- Remember to customize `trace/<provider>.dataset`. Each provider uses a different format but the main structure is taken from [LLMLoadgen](https://github.com/hyscale-lab/LLMLoadgen)'s `test_azure.json`.
- Load generator results are in `trace/<provider>.result`.
- Graphs are saved in `benchmark_graph/trace`.
- Check proxy traffic log in `proxy/traffic.log`.

## Note
- Does not support streaming. Requests with `"stream": true` are simply ignored.
- Does not support DynamoDB. `"backend": true` should yield an error.
- Most load generator arguments are not by user input, e.g. `sampling_rate`, `recur_step`, `max_drift`
- No test currently